### PR TITLE
Improve responsive layouts for clients and about pages

### DIFF
--- a/src/Component/AboutusComponent/IndustryImpact.jsx
+++ b/src/Component/AboutusComponent/IndustryImpact.jsx
@@ -3,14 +3,19 @@ import React from "react";
 
 
 export default function IndustryImpact({ cardsData }) {
+    const staggerClasses = {
+        "md:mt-0": "md:mt-0",
+        "md:mt-12": "md:mt-12",
+    };
+
     return (
         <div className="px-6 md:px-[72px] my-10  ">
             <h2 className="text-3xl md:text-[40px] font-unbounded font-bold mb-4">Industry Impact</h2>
-            <div className="flex gap-5 mt-10">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 mt-10">
                 {cardsData.map((item, idx) => (
                     <div
                         key={idx}
-                        className={`h-[394px] border border-gray-300 rounded-lg shadow-sm px-5 py-6 flex flex-col ${item.position}`}
+                        className={`h-[394px] border border-gray-300 rounded-lg shadow-sm px-5 py-6 flex flex-col ${staggerClasses[item.position] ?? ""}`}
                     >
                         <h3 className="text-[35px] font-semibold  font-unbounded mb-3">{item.title}</h3>
                         <p className="text-[18px] text-[#000000] font-montserrat leading-relaxed mt-15">{item.desc}</p>

--- a/src/Component/AboutusComponent/Mission.jsx
+++ b/src/Component/AboutusComponent/Mission.jsx
@@ -47,9 +47,9 @@ export default function Mission() {
                     We work to create most attractive & meaningful place for small businesses. Our Team always ready to help You
                 </p>
 
-                <div className="flex justify-center gap-10 p-10">
+                <div className="mt-8 flex flex-col gap-8 md:flex-row md:justify-center md:gap-10 md:p-10">
                     {data.map((item, idx) => (
-                        <div key={idx} className={`relative pb-8 rounded-xl  shadow-md  ${item.color}`}>
+                        <div key={idx} className={`relative w-full md:w-1/3 pb-8 rounded-xl shadow-md ${item.color}`}>
                             {/* Main Card */}
                             <div
                                 className={` rounded-xl p-6 text-white `}
@@ -58,11 +58,11 @@ export default function Mission() {
                                     {item.label}
                                 </span>
                                 <h2 className="text-[35px] font-semibold font-unbounded mt-4">{item.title}</h2>
-                                <p className="mt-3 text-[18px] leading-relaxedm font-montserrat ">{item.desc}</p>
+                                <p className="mt-3 text-[18px] leading-relaxed font-montserrat ">{item.desc}</p>
                             </div>
 
                             {/* Small Overlapping Card */}
-                            <div className="absolute -bottom-20 -right-8  bg-white  p-4 shadow-lg ">
+                            <div className="mt-6 mx-6 bg-white p-4 shadow-lg md:absolute md:mt-0 md:mx-0 md:-bottom-20 md:-right-8">
                                 <div className="flex justify-between gap-5 items-center">
                                     <div>
                                         <h3 className="font-semibold text-[35px] font-unbounded text-[#7F7F7F]">

--- a/src/Component/AboutusComponent/OurSuccess.jsx
+++ b/src/Component/AboutusComponent/OurSuccess.jsx
@@ -1,25 +1,35 @@
-import { success } from '@/AllAssets/AllAsssets'
-import Image from 'next/image'
-import React from 'react'
+import { success } from "@/AllAssets/AllAsssets";
+import Image from "next/image";
+import React from "react";
 
 const OurSuccess = () => {
     return (
-        <>
-            <div className='flex px-6 md:px-[72px] my-10'>
-                <div className='w-1/2 space-y-5'>
-                    <h2 className='font-unbounded font-bold text-[40px]'>Our Story the Journey That Shaped Our Success</h2>
-                    <p className='font-montserrat text-[18px]'>Frustrated by siloed marketing and clunky tech, two friends a growth marketer and a full-stack engineer founded QuantumCrafters
-                        Studio in 2025. Their vision: blend data-driven marketing with intelligent automation so businesses can grow faster, spend smarter
-                        and work lighter.</p>
-                        <button className='font-montserrat font-bold text-[16px] bg-[#F1813B] px-6 py-2 text-white rounded-lg'>Get Started a Project</button>
-
-                </div>
-                <div className='w-1/2'>
-                    <Image src={success} width={559} height={100} alt='success' className='object-contain' />
-                </div>
+        <div className="flex flex-col-reverse items-center gap-8 px-6 md:px-[72px] my-10 md:flex-row">
+            <div className="w-full md:w-1/2 space-y-5 text-center md:text-left">
+                <h2 className="font-unbounded font-bold text-3xl md:text-[40px]">
+                    Our Story the Journey That Shaped Our Success
+                </h2>
+                <p className="font-montserrat text-base md:text-[18px]">
+                    Frustrated by siloed marketing and clunky tech, two friends—a growth marketer and a full-stack engineer—
+                    founded QuantumCrafters Studio in 2025. Their vision: blend data-driven marketing with intelligent
+                    automation so businesses can grow faster, spend smarter, and work lighter.
+                </p>
+                <button className="font-montserrat font-bold text-[16px] bg-[#F1813B] px-6 py-2 text-white rounded-lg">
+                    Get Started a Project
+                </button>
             </div>
-        </>
-    )
-}
+            <div className="flex w-full justify-center md:w-1/2">
+                <Image
+                    src={success}
+                    width={559}
+                    height={100}
+                    alt="success"
+                    className="h-auto w-full max-w-[559px] object-contain"
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                />
+            </div>
+        </div>
+    );
+};
 
-export default OurSuccess
+export default OurSuccess;

--- a/src/Component/FooterComponent/Footer.jsx
+++ b/src/Component/FooterComponent/Footer.jsx
@@ -11,14 +11,14 @@ const Footer = () => {
     <>
       <footer className='bg-black text-white py-5 px-10 mt-10 rounded-ss-3xl w-full rounded-se-3xl'>
         <div className=' mx-auto'>
-          <div className='flex flex-col md:flex-row justify-between items-start md:items-center mb-8'>
+          <div className='flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-10 md:gap-0'>
             <div className='lg:w-[45%]  '>
               <div className='flex'>
                 <Image src={footerlogo} alt="logo" width={569.86} height={117} />
               </div>
               <p className={`text-[#FFFFFF]  mt-4 text-lg leading-relaxed px-4 md:px-0 text-center md:text-start  lg:w-[72%] font-unbounded `}>The next big thing starts here— drop us a line and let's get creating!</p>
             </div>
-            <div className='flex md:justify-normal items-start  space-x-20 sm:space-x-80  md:space-x-24 mt-8 md:mt-0'>
+            <div className='flex flex-col sm:flex-row items-start gap-8 md:gap-24 mt-8 md:mt-0'>
               <div>
                 <h2 className={`font-semibold mb-4 text-[15px] font-unbounded`}>Quick Links</h2>
                 <ul className={`text-[#FFFFFF] space-y-3 text-sm font-montserrat`}>
@@ -88,7 +88,7 @@ const Footer = () => {
 
             <div className='border-t border-gray-700 '></div>
           </div>
-          <div className={`flex justify-between text-[#FFFFFF] text-[15px] mt-3  font-montserrat`}>
+          <div className={`mt-3 flex flex-col gap-3 text-center text-[#FFFFFF] text-[15px] font-montserrat md:flex-row md:items-center md:justify-between md:text-left`}>
             <span>
               © 2025 QuantumCrafters Studio Pvt. Ltd. All rights reserved.
             </span>

--- a/src/Component/HomeComponent/Clients.jsx
+++ b/src/Component/HomeComponent/Clients.jsx
@@ -10,7 +10,7 @@ import Image from "next/image";
 
 
 const Clients = () => {
-    const [activeIndex, setActiveIndex] = useState(2)
+    const [activeIndex, setActiveIndex] = useState(0)
 
 
     return (
@@ -28,20 +28,37 @@ const Clients = () => {
             <div className="relative flex flex-col items-center">
                 <Swiper
                     modules={[Navigation]}
-                    spaceBetween={15}
-                    slidesPerView={6}
+                    spaceBetween={16}
+                    slidesPerView={1}
                     loop={true}
                     initialSlide={0}
                     navigation={{
                         nextEl: ".custom-next1",
                         prevEl: ".custom-prev1",
                     }}
+                    breakpoints={{
+                        640: {
+                            slidesPerView: 2,
+                            spaceBetween: 20,
+                        },
+                        768: {
+                            slidesPerView: 3,
+                            spaceBetween: 24,
+                        },
+                        1024: {
+                            slidesPerView: 4,
+                            spaceBetween: 24,
+                        },
+                        1280: {
+                            slidesPerView: 6,
+                            spaceBetween: 24,
+                        },
+                    }}
+                    onSwiper={(swiper) => {
+                        setActiveIndex(swiper.realIndex);
+                    }}
                     onSlideChange={(swiper) => {
-                        const current = swiper.slides[swiper.activeIndex + 2];
-                        if (current) {
-                            const realIndex = current.getAttribute("data-swiper-slide-index");
-                            setActiveIndex(Number(realIndex));
-                        }
+                        setActiveIndex(swiper.realIndex);
                     }}
                     scrollbar={true}
                     grabCursor={true}       // cursor ko grab banata hai

--- a/src/Component/ServiceComponent/Strategy.jsx
+++ b/src/Component/ServiceComponent/Strategy.jsx
@@ -22,7 +22,13 @@ export default function Strategy({ heading, desc, cards }) {
                         >
                             {/* Background Image on Hover */}
                             <div className="absolute inset-0 transition-opacity duration-500 opacity-0 group-hover:opacity-100">
-                                <Image src={card.image} alt={card.title} fill className="object-cover" />
+                                <Image
+                                    src={card.image}
+                                    alt={card.title}
+                                    fill
+                                    className="object-cover"
+                                    sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                                />
                             </div>
 
                             {/* Dark Overlay */}

--- a/src/Data/Aboutus/IndustryImpact.jsx
+++ b/src/Data/Aboutus/IndustryImpact.jsx
@@ -2,21 +2,21 @@ export const Aboutusindustries = [
   {
     title: "SaaS",
     desc: "40% CAC reduction; onboarding emails automated to real-time.",
-    position: "mt-0", // top
+    position: "md:mt-0", // top
   },
   {
     title: "D2C",
     desc: "5× organic traffic; 28% lift in AOV through predictive ads.",
-    position: "mt-12", // down
+    position: "md:mt-12", // down
   },
   {
     title: "eCommerce",
     desc: "12 hrs/report saved via automated dashboards; 20% ROAS uplift.",
-    position: "mt-0", // top
+    position: "md:mt-0", // top
   },
   {
     title: "FinTech",
     desc: "Generated 1,200 monthly leads via voice-first SEO & chatbots.",
-    position: "mt-12", // down
+    position: "md:mt-12", // down
   },
 ];


### PR DESCRIPTION
## Summary
- make the home clients carousel responsive and keep the active card indicator in sync
- update about page sections and the footer to stack cleanly on small screens
- add responsive image sizing hints to reduce unnecessary bandwidth

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d676fcc6e08329b46b7d8c67b3425a